### PR TITLE
change of wording in registrations new

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Signing up</h2>
+<h2>Signing in is fun</h2>
 
 <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= f.error_notification %>


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2022-01-29 at 10 31 25" src="https://user-images.githubusercontent.com/26467014/151655785-7c3139c6-efa1-40d8-bdc8-236306949dd3.png">
![Screenshot 2022-01-29 at 10 31 25 (2)](https://user-images.githubusercontent.com/26467014/151655791-931fccbf-a6f7-4d35-82d3-a27a9c6302ed.png)
